### PR TITLE
Update markdown files for GFM changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 btclog
 ======
 
-[![Build Status](https://travis-ci.org/btcsuite/btclog.png?branch=master)]
-(https://travis-ci.org/btcsuite/btclog)
+[![Build Status](http://img.shields.io/travis/btcsuite/btclog.svg)](https://travis-ci.org/btcsuite/btclog)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btclog)
 
 Package btclog implements a subsystem aware logger backed by seelog.
 
@@ -13,16 +14,6 @@ files.  That is where this package comes in.  It provides a SubsystemLogger
 which accepts the backend seelog logger to do the real work.  Each instance of a
 SubsystemLogger then allows you specify (and retrieve) an individual level per
 subsystem.  All messages are then passed along to the backend seelog logger.
-
-## Documentation
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btclog
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btclog
 
 ## Installation
 
@@ -52,4 +43,5 @@ verify the signature perform the following:
 
 ## License
 
-Package btclog is licensed under the liberal ISC License.
+Package btclog is licensed under the [copyfree](http://copyfree.org) ISC
+License.


### PR DESCRIPTION
The github markdown interpreter has been changed such that it no longer allows spaces in between the brackets and parenthesis of links.  This updates the markdown files accordingly.

While here, it also corrects a couple of inconsistencies in regards to other `README.md` files in the project.