### PR TITLE
Add flags mechanism and callsite options.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,5 +13,15 @@ The default implementation in this package must be created by the Backend type.
 Backends can write to any io.Writer, including multi-writers created by
 io.MultiWriter.  Multi-writers allow log output to be written to many writers,
 including standard output and log files.
+
+Optional logging behavior can be specified by using the LOGFLAGS environment
+variable and overridden per-Backend by using the WithFlags call option. Multiple
+LOGFLAGS options can be specified, separated by commas.  The following options
+are recognized:
+
+  longfile: Include the full filepath and line number in all log messages
+
+  shortfile: Include the filename and line number in all log messages.
+  Overrides longfile.
 */
 package btclog


### PR DESCRIPTION
Flags have been added to include the file name/path and line number of
the log callsite in all log messages.

Flags can be configured using the LOGFLAGS environment variable as
well as explicitly setting the flags on a backend in code using
WithFlags.

Inspired by the Lshortfile/Llongfile flags for the stdlib log package.

Closes #12.