### PR TITLE
build: add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/btcsuite/btclog
+
+go 1.17.0


### PR DESCRIPTION
The project is so old, that it predates modules entirely. 

With this PR, we add a fresh `go.mod` file. Once this is merged, we can tag the first module version. This will allow us to more easily navigate potentail upcoming changes that expand functionality, but require a newer Go version. 