### PR TITLE
v2/log: check log level before using fmt.Sprint calls

### DIFF
--- a/v2/attrs.go
+++ b/v2/attrs.go
@@ -51,9 +51,9 @@ type attrsKey struct{}
 //
 // Usage:
 //
-//	ctx := log.WithCtx(ctx, "height", 1234)
+//	unusedCtx := log.WithCtx(unusedCtx, "height", 1234)
 //	...
-//	log.Info(ctx, "Height processed") // Will contain attribute: height=1234
+//	log.Info(unusedCtx, "Height processed") // Will contain attribute: height=1234
 func WithCtx(ctx context.Context, attrs ...any) context.Context {
 	return context.WithValue(ctx, attrsKey{}, mergeAttrs(ctx, attrs))
 }

--- a/v2/attrs.go
+++ b/v2/attrs.go
@@ -6,11 +6,19 @@ import (
 	"log/slog"
 )
 
-// Hex is a convenience function for a hex-encoded log attributes.
+// Hex is a convenience function for hex-encoded log attributes.
 func Hex(key string, value []byte) slog.Attr {
-	h := hex.EncodeToString(value)
+	return slog.String(key, hex.EncodeToString(value))
+}
 
-	return slog.String(key, h)
+// Hex6 is a convenience function for hex-encoded log attributes which prints
+// a maximum of 6 bytes.
+func Hex6(key string, value []byte) slog.Attr {
+	if len(value) <= 6 {
+		return slog.String(key, hex.EncodeToString(value))
+	}
+
+	return slog.String(key, hex.EncodeToString(value[:6]))
 }
 
 type attrsKey struct{}

--- a/v2/attrs.go
+++ b/v2/attrs.go
@@ -21,6 +21,29 @@ func Hex6(key string, value []byte) slog.Attr {
 	return slog.String(key, hex.EncodeToString(value[:6]))
 }
 
+// Fmt returns a slog.Attr with the formatted message which is only computed
+// when needed.
+//
+// Example usage:
+//
+//	log.InfoS(ctx, "Main message", Fmt("key", "%.12f", 3.241))
+func Fmt(key string, msg string, params ...any) slog.Attr {
+	return slog.Any(key, Sprintf(msg, params...))
+}
+
+// ClosureAttr returns an slog attribute that will only perform the given
+// logging operation if the corresponding log level is enabled.
+//
+// Example usage:
+//
+//	log.InfoS(ctx, "msg", ClosureAttr("key", func() string {
+//		// Replace with an expensive string computation call.
+//		return "expensive string"
+//	}))
+func ClosureAttr(key string, compute func() string) slog.Attr {
+	return slog.Any(key, NewClosure(compute))
+}
+
 type attrsKey struct{}
 
 // WithCtx returns a copy of the context with which the logging attributes are

--- a/v2/closure.go
+++ b/v2/closure.go
@@ -1,0 +1,35 @@
+package btclog
+
+import (
+	"fmt"
+)
+
+// Closure is used to provide a closure over expensive logging operations so
+// that they don't have to be performed when the logging level doesn't warrant
+// it.
+type Closure func() string
+
+// String invokes the underlying function and returns the result.
+func (c Closure) String() string {
+	return c()
+}
+
+// NewClosure returns a new closure over a function that returns a string
+// which itself provides a Stringer interface so that it can be used with the
+// logging system.
+func NewClosure(compute func() string) Closure {
+	return compute
+}
+
+// Sprintf returns a fmt.Stringer that will lazily compute the string when
+// needed. This is useful when the string is expensive to compute and may not be
+// needed due to the log level being used.
+//
+// Example usage:
+//
+//	log.InfoS(ctx, "msg", "key", Sprintf("%.12f", 3.241))
+func Sprintf(msg string, params ...any) fmt.Stringer {
+	return NewClosure(func() string {
+		return fmt.Sprintf(msg, params...)
+	})
+}

--- a/v2/handler.go
+++ b/v2/handler.go
@@ -54,7 +54,7 @@ func defaultHandlerOpts() *handlerOpts {
 	return &handlerOpts{
 		flag:              defaultFlags,
 		withTimestamp:     true,
-		callSiteSkipDepth: 6,
+		callSiteSkipDepth: 5,
 	}
 }
 

--- a/v2/handler.go
+++ b/v2/handler.go
@@ -13,6 +13,11 @@ import (
 	"github.com/btcsuite/btclog"
 )
 
+// DefaultSkipDepth is the default number of stack frames to ascend when
+// determining the call site of a log. Users of this package may want to alter
+// this depth depending on if they wrap the logger at all.
+const DefaultSkipDepth = 5
+
 // HandlerOption is the signature of a functional option that can be used to
 // modify the behaviour of the DefaultHandler.
 type HandlerOption func(*handlerOpts)
@@ -54,7 +59,7 @@ func defaultHandlerOpts() *handlerOpts {
 	return &handlerOpts{
 		flag:              defaultFlags,
 		withTimestamp:     true,
-		callSiteSkipDepth: 5,
+		callSiteSkipDepth: DefaultSkipDepth,
 	}
 }
 

--- a/v2/handler_test.go
+++ b/v2/handler_test.go
@@ -4,125 +4,149 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/btcsuite/btclog"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/btcsuite/btclog"
 )
 
 // TestDefaultHandler tests that the DefaultHandler's output looks as expected.
 func TestDefaultHandler(t *testing.T) {
 	t.Parallel()
 
-	timeSource := func() time.Time {
-		return time.Unix(100, 100)
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := test.handlerConstructor(&buf)
+			handler.SetLevel(test.level)
 
-	tests := []struct {
-		name               string
-		handlerConstructor func(w io.Writer) Handler
-		level              btclog.Level
-		logFunc            func(log Logger)
-		expectedLog        string
-	}{
-		{
-			name: "Basic calls and levels",
-			handlerConstructor: func(w io.Writer) Handler {
-				return NewDefaultHandler(
-					w, WithTimeSource(timeSource),
-				)
-			},
-			level: LevelDebug,
-			logFunc: func(log Logger) {
-				log.Info("Test Basic Log")
-				log.Debugf("Test basic log with %s", "format")
-				log.Trace("Log should not appear due to level")
-			},
-			expectedLog: `1970-01-01 02:01:40.000 [INF]: Test Basic Log
-1970-01-01 02:01:40.000 [DBG]: Test basic log with format
-`,
+			if handler.Level() != test.level {
+				t.Fatalf("Incorrect level. Expected %s, "+
+					"got %s", test.level, handler.Level())
+			}
+
+			test.logFunc(NewSLogger(handler))
+
+			if buf.String() != test.expectedLog {
+				t.Fatalf("Log result mismatch. Expected "+
+					"\n\"%s\", got \n\"%s\"",
+					test.expectedLog, buf.Bytes())
+			}
+		})
+	}
+}
+
+var timeSource = func() time.Time {
+	return time.Date(2009, time.January, 3, 12, 0, 0, 0, time.UTC)
+
+}
+
+var tests = []struct {
+	name               string
+	handlerConstructor func(w io.Writer) Handler
+	level              btclog.Level
+	logFunc            func(log Logger)
+	expectedLog        string
+}{
+	{
+		name: "Basic calls and levels",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(
+				w, WithTimeSource(timeSource),
+			)
 		},
-		{
-			name: "Call site",
-			handlerConstructor: func(w io.Writer) Handler {
-				return NewDefaultHandler(
-					w, WithNoTimestamp(),
-					WithCallSiteSkipDepth(7),
-					WithCallerFlags(Lshortfile),
-				)
-			},
-			level: LevelInfo,
-			logFunc: func(log Logger) {
-				log.Info("Test Basic Log")
-			},
-			expectedLog: `[INF] handler_test.go:196: Test Basic Log
-`,
+		level: LevelDebug,
+		logFunc: func(log Logger) {
+			log.Info("Test Basic Log")
+			log.Debugf("Test basic log with %s", "format")
+			log.Trace("Log should not appear due to level")
 		},
-		{
-			name: "Sub-system tag",
-			handlerConstructor: func(w io.Writer) Handler {
-				h := NewDefaultHandler(w, WithNoTimestamp())
-				return h.SubSystem("SUBS")
-			},
-			level: LevelInfo,
-			logFunc: func(log Logger) {
-				log.Info("Test Basic Log")
-			},
-			expectedLog: `[INF] SUBS: Test Basic Log
+		expectedLog: `2009-01-03 12:00:00.000 [INF]: Test Basic Log
+2009-01-03 12:00:00.000 [DBG]: Test basic log with format
 `,
+	},
+	{
+		name: "Call site",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(
+				w, WithNoTimestamp(),
+				WithCallSiteSkipDepth(7),
+				WithCallerFlags(Lshortfile),
+			)
 		},
-		{
-			name: "Test all levels",
-			handlerConstructor: func(w io.Writer) Handler {
-				return NewDefaultHandler(w, WithNoTimestamp())
-			},
-			level: LevelTrace,
-			logFunc: func(log Logger) {
-				log.Trace("Trace")
-				log.Debug("Debug")
-				log.Info("Info")
-				log.Warn("Warn")
-				log.Error("Error")
-				log.Critical("Critical")
-			},
-			expectedLog: `[TRC]: Trace
+		level: LevelInfo,
+		logFunc: func(log Logger) {
+			log.Info("Test Basic Log")
+		},
+		expectedLog: `[INF] handler_test.go:29: Test Basic Log
+`,
+	},
+	{
+		name: "Sub-system tag",
+		handlerConstructor: func(w io.Writer) Handler {
+			h := NewDefaultHandler(w, WithNoTimestamp())
+			return h.SubSystem("SUBS")
+		},
+		level: LevelInfo,
+		logFunc: func(log Logger) {
+			log.Info("Test Basic Log")
+		},
+		expectedLog: `[INF] SUBS: Test Basic Log
+`,
+	},
+	{
+		name: "Test all levels",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(w, WithNoTimestamp())
+		},
+		level: LevelTrace,
+		logFunc: func(log Logger) {
+			log.Trace("Trace")
+			log.Debug("Debug")
+			log.Info("Info")
+			log.Warn("Warn")
+			log.Error("Error")
+			log.Critical("Critical")
+		},
+		expectedLog: `[TRC]: Trace
 [DBG]: Debug
 [INF]: Info
 [WRN]: Warn
 [ERR]: Error
 [CRT]: Critical
 `,
+	},
+	{
+		name: "Structured Logs",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(w, WithNoTimestamp())
 		},
-		{
-			name: "Structured Logs",
-			handlerConstructor: func(w io.Writer) Handler {
-				return NewDefaultHandler(w, WithNoTimestamp())
-			},
-			level: LevelInfo,
-			logFunc: func(log Logger) {
-				ctx := context.Background()
-				log.InfoS(ctx, "No attributes")
-				log.InfoS(ctx, "Single word attribute", "key", "value")
-				log.InfoS(ctx, "Multi word string value", "key with spaces", "value")
-				log.InfoS(ctx, "Number attribute", "key", 5)
-				log.InfoS(ctx, "Bad key", "key")
+		level: LevelInfo,
+		logFunc: func(log Logger) {
+			ctx := context.Background()
+			log.InfoS(ctx, "No attributes")
+			log.InfoS(ctx, "Single word attribute", "key", "value")
+			log.InfoS(ctx, "Multi word string value", "key with spaces", "value")
+			log.InfoS(ctx, "Number attribute", "key", 5)
+			log.InfoS(ctx, "Bad key", "key")
 
-				type b struct {
-					name    string
-					age     int
-					address *string
-				}
+			type b struct {
+				name    string
+				age     int
+				address *string
+			}
 
-				var c *b
-				log.InfoS(ctx, "Nil pointer value", "key", c)
+			var c *b
+			log.InfoS(ctx, "Nil pointer value", "key", c)
 
-				c = &b{name: "Bob", age: 5}
-				log.InfoS(ctx, "Struct values", "key", c)
+			c = &b{name: "Bob", age: 5}
+			log.InfoS(ctx, "Struct values", "key", c)
 
-				ctx = WithCtx(ctx, "request_id", 5, "user_name", "alice")
-				log.InfoS(ctx, "Test context attributes", "key", "value")
-			},
-			expectedLog: `[INF]: No attributes
+			ctx = WithCtx(ctx, "request_id", 5, "user_name", "alice")
+			log.InfoS(ctx, "Test context attributes", "key", "value")
+		},
+		expectedLog: `[INF]: No attributes
 [INF]: Single word attribute key=value
 [INF]: Multi word string value "key with spaces"=value
 [INF]: Number attribute key=5
@@ -131,39 +155,39 @@ func TestDefaultHandler(t *testing.T) {
 [INF]: Struct values key="&{name:Bob age:5 address:<nil>}"
 [INF]: Test context attributes request_id=5 user_name=alice key=value
 `,
+	},
+	{
+		name: "Error logs",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(w, WithNoTimestamp())
 		},
-		{
-			name: "Error logs",
-			handlerConstructor: func(w io.Writer) Handler {
-				return NewDefaultHandler(w, WithNoTimestamp())
-			},
-			level: LevelInfo,
-			logFunc: func(log Logger) {
-				log.Error("Error string")
-				log.Errorf("Error formatted string")
+		level: LevelInfo,
+		logFunc: func(log Logger) {
+			log.Error("Error string")
+			log.Errorf("Error formatted string")
 
-				ctx := context.Background()
-				log.ErrorS(ctx, "Structured error log with nil error", nil)
-				log.ErrorS(ctx, "Structured error with non-nil error", errors.New("oh no"))
-				log.ErrorS(ctx, "Structured error with attributes", errors.New("oh no"), "key", "value")
+			ctx := context.Background()
+			log.ErrorS(ctx, "Structured error log with nil error", nil)
+			log.ErrorS(ctx, "Structured error with non-nil error", errors.New("oh no"))
+			log.ErrorS(ctx, "Structured error with attributes", errors.New("oh no"), "key", "value")
 
-				log.Warn("Warning string")
-				log.Warnf("Warning formatted string")
+			log.Warn("Warning string")
+			log.Warnf("Warning formatted string")
 
-				ctx = context.Background()
-				log.WarnS(ctx, "Structured warning log with nil error", nil)
-				log.WarnS(ctx, "Structured warning with non-nil error", errors.New("oh no"))
-				log.WarnS(ctx, "Structured warning with attributes", errors.New("oh no"), "key", "value")
+			ctx = context.Background()
+			log.WarnS(ctx, "Structured warning log with nil error", nil)
+			log.WarnS(ctx, "Structured warning with non-nil error", errors.New("oh no"))
+			log.WarnS(ctx, "Structured warning with attributes", errors.New("oh no"), "key", "value")
 
-				log.Critical("Critical string")
-				log.Criticalf("Critical formatted string")
+			log.Critical("Critical string")
+			log.Criticalf("Critical formatted string")
 
-				ctx = context.Background()
-				log.CriticalS(ctx, "Structured critical log with nil error", nil)
-				log.CriticalS(ctx, "Structured critical with non-nil error", errors.New("oh no"))
-				log.CriticalS(ctx, "Structured critical with attributes", errors.New("oh no"), "key", "value")
-			},
-			expectedLog: `[ERR]: Error string
+			ctx = context.Background()
+			log.CriticalS(ctx, "Structured critical log with nil error", nil)
+			log.CriticalS(ctx, "Structured critical with non-nil error", errors.New("oh no"))
+			log.CriticalS(ctx, "Structured critical with attributes", errors.New("oh no"), "key", "value")
+		},
+		expectedLog: `[ERR]: Error string
 [ERR]: Error formatted string
 [ERR]: Structured error log with nil error
 [ERR]: Structured error with non-nil error err="oh no"
@@ -179,27 +203,5 @@ func TestDefaultHandler(t *testing.T) {
 [CRT]: Structured critical with non-nil error err="oh no"
 [CRT]: Structured critical with attributes err="oh no" key=value
 `,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			handler := test.handlerConstructor(&buf)
-			handler.SetLevel(test.level)
-
-			if handler.Level() != test.level {
-				t.Fatalf("Incorrect level. Expected %s, "+
-					"got %s", test.level, handler.Level())
-			}
-
-			test.logFunc(NewSLogger(handler))
-
-			if string(buf.Bytes()) != test.expectedLog {
-				t.Fatalf("Log result mismatch. Expected "+
-					"\n\"%s\", got \n\"%s\"",
-					test.expectedLog, buf.Bytes())
-			}
-		})
-	}
+	},
 }

--- a/v2/handler_test.go
+++ b/v2/handler_test.go
@@ -204,4 +204,27 @@ var tests = []struct {
 [CRT]: Structured critical with attributes err="oh no" key=value
 `,
 	},
+	{
+		name: "Slog Helpers",
+		handlerConstructor: func(w io.Writer) Handler {
+			return NewDefaultHandler(w, WithNoTimestamp())
+		},
+		level: LevelInfo,
+		logFunc: func(log Logger) {
+			ctx := context.Background()
+			log.InfoS(ctx, "msg", Hex("hex_val", []byte{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			}))
+			log.InfoS(ctx, "msg", Hex6("hex_val", []byte{
+				0x01, 0x02,
+			}))
+			log.InfoS(ctx, "msg", Hex6("hex_val", []byte{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			}))
+		},
+		expectedLog: `[INF]: msg hex_val=0102030405060708
+[INF]: msg hex_val=0102
+[INF]: msg hex_val=010203040506
+`,
+	},
 }

--- a/v2/handler_test.go
+++ b/v2/handler_test.go
@@ -20,14 +20,15 @@ func TestDefaultHandler(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			handler := test.handlerConstructor(&buf)
-			handler.SetLevel(test.level)
+			logger := NewSLogger(handler)
+			logger.SetLevel(test.level)
 
 			if handler.Level() != test.level {
 				t.Fatalf("Incorrect level. Expected %s, "+
 					"got %s", test.level, handler.Level())
 			}
 
-			test.logFunc(t, NewSLogger(handler))
+			test.logFunc(t, logger)
 
 			if buf.String() != test.expectedLog {
 				t.Fatalf("Log result mismatch. Expected "+
@@ -80,7 +81,7 @@ var tests = []struct {
 		logFunc: func(t *testing.T, log Logger) {
 			log.Info("Test Basic Log")
 		},
-		expectedLog: `[INF] handler_test.go:30: Test Basic Log
+		expectedLog: `[INF] handler_test.go:31: Test Basic Log
 `,
 	},
 	{
@@ -285,11 +286,11 @@ var tests = []struct {
 			log.InfoS(ctx, "Number attribute", "key", 5)
 			log.InfoS(ctx, "Bad key", "key")
 		},
-		expectedLog: `[INF] handler_test.go:30: No attributes
-[INF] handler_test.go:30: Single word attribute key=value
-[INF] handler_test.go:30: Multi word string value "key with spaces"=value
-[INF] handler_test.go:30: Number attribute key=5
-[INF] handler_test.go:30: Bad key !BADKEY=key
+		expectedLog: `[INF] handler_test.go:31: No attributes
+[INF] handler_test.go:31: Single word attribute key=value
+[INF] handler_test.go:31: Multi word string value "key with spaces"=value
+[INF] handler_test.go:31: Number attribute key=5
+[INF] handler_test.go:31: Bad key !BADKEY=key
 `,
 	},
 }

--- a/v2/handler_test.go
+++ b/v2/handler_test.go
@@ -40,7 +40,6 @@ func TestDefaultHandler(t *testing.T) {
 
 var timeSource = func() time.Time {
 	return time.Date(2009, time.January, 3, 12, 0, 0, 0, time.UTC)
-
 }
 
 var tests = []struct {
@@ -86,6 +85,27 @@ var tests = []struct {
 			subLog.Trace("Test Basic Log")
 		},
 		expectedLog: `[TRC] SUBS: Test Basic Log
+`,
+	},
+	{
+		name:        "Prefixed logging",
+		handlerOpts: []HandlerOption{WithNoTimestamp()},
+		level:       LevelTrace,
+		logFunc: func(t *testing.T, log Logger) {
+			// We use trace level to ensure that logger level is
+			// carried over to the new prefixed logger.
+			log.Tracef("Test Basic Log")
+
+			subLog := log.SubSystem("SUBS")
+			subLog.Tracef("Test Basic Log")
+
+			pLog := subLog.WithPrefix("(Client)")
+			pLog.Tracef("Test Basic Log")
+
+		},
+		expectedLog: `[TRC]: Test Basic Log
+[TRC] SUBS: Test Basic Log
+[TRC] SUBS: (Client) Test Basic Log
 `,
 	},
 	{

--- a/v2/handler_test.go
+++ b/v2/handler_test.go
@@ -72,7 +72,7 @@ var tests = []struct {
 		handlerConstructor: func(w io.Writer) Handler {
 			return NewDefaultHandler(
 				w, WithNoTimestamp(),
-				WithCallSiteSkipDepth(7),
+				WithCallSiteSkipDepth(6),
 				WithCallerFlags(Lshortfile),
 			)
 		},
@@ -255,7 +255,7 @@ var tests = []struct {
 		handlerConstructor: func(w io.Writer) Handler {
 			return NewDefaultHandler(
 				w, WithNoTimestamp(),
-				WithCallSiteSkipDepth(7),
+				WithCallSiteSkipDepth(6),
 				WithCallerFlags(Lshortfile),
 				WithStyledKeys(func(s string) string {
 					return s

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -2,6 +2,7 @@ package btclog
 
 import (
 	"context"
+
 	"github.com/btcsuite/btclog"
 )
 
@@ -96,6 +97,11 @@ type Logger interface {
 	// SubSystem returns a copy of the logger but with the new subsystem
 	// tag.
 	SubSystem(tag string) Logger
+
+	// WithPrefix returns a copy of the logger but with the given string
+	// prefixed to each log message. Note that the subsystem of the original
+	// logger is kept but any existing prefix is overridden.
+	WithPrefix(prefix string) Logger
 }
 
 // Ensure that the Logger implements the btclog.Logger interface so that an

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -92,6 +92,10 @@ type Logger interface {
 
 	// SetLevel changes the logging level to the passed level.
 	SetLevel(level btclog.Level)
+
+	// SubSystem returns a copy of the logger but with the new subsystem
+	// tag.
+	SubSystem(tag string) Logger
 }
 
 // Ensure that the Logger implements the btclog.Logger interface so that an

--- a/v2/log.go
+++ b/v2/log.go
@@ -218,6 +218,10 @@ func (l *sLogger) CriticalS(ctx context.Context, msg string, err error,
 // contains a format string and parameters for the string into the appropriate
 // form expected by the structured logger.
 func (l *sLogger) toSlogf(level slog.Level, format string, params ...any) {
+	if !l.Enabled(l.unusedCtx, level) {
+		return
+	}
+
 	l.logger.Log(l.unusedCtx, level, fmt.Sprintf(format, params...))
 }
 
@@ -225,6 +229,10 @@ func (l *sLogger) toSlogf(level slog.Level, format string, params ...any) {
 // contains a number of parameters into the appropriate form expected by the
 // structured logger.
 func (l *sLogger) toSlog(level slog.Level, v ...any) {
+	if !l.Enabled(l.unusedCtx, level) {
+		return
+	}
+
 	l.logger.Log(l.unusedCtx, level, fmt.Sprint(v...))
 }
 
@@ -232,6 +240,10 @@ func (l *sLogger) toSlog(level slog.Level, v ...any) {
 // to access the underlying logger.
 func (l *sLogger) toSlogS(ctx context.Context, level slog.Level, msg string,
 	attrs ...any) {
+
+	if !l.Enabled(ctx, level) {
+		return
+	}
 
 	l.logger.Log(ctx, level, msg, mergeAttrs(ctx, attrs)...)
 }

--- a/v2/log.go
+++ b/v2/log.go
@@ -58,7 +58,11 @@ func NewSLogger(handler Handler) Logger {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Tracef(format string, params ...any) {
-	l.toSlogf(levelTrace, format, params...)
+	if !l.Enabled(l.unusedCtx, levelTrace) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelTrace, fmt.Sprintf(format, params...))
 }
 
 // Debugf creates a formatted message from the to format specifier along with
@@ -66,7 +70,11 @@ func (l *sLogger) Tracef(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Debugf(format string, params ...any) {
-	l.toSlogf(levelDebug, format, params...)
+	if !l.Enabled(l.unusedCtx, levelDebug) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelDebug, fmt.Sprintf(format, params...))
 }
 
 // Infof creates a formatted message from the to format specifier along with
@@ -74,7 +82,11 @@ func (l *sLogger) Debugf(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Infof(format string, params ...any) {
-	l.toSlogf(levelInfo, format, params...)
+	if !l.Enabled(l.unusedCtx, levelInfo) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelInfo, fmt.Sprintf(format, params...))
 }
 
 // Warnf creates a formatted message from the to format specifier along with
@@ -82,7 +94,11 @@ func (l *sLogger) Infof(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Warnf(format string, params ...any) {
-	l.toSlogf(levelWarn, format, params...)
+	if !l.Enabled(l.unusedCtx, levelWarn) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelWarn, fmt.Sprintf(format, params...))
 }
 
 // Errorf creates a formatted message from the to format specifier along with
@@ -90,7 +106,11 @@ func (l *sLogger) Warnf(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Errorf(format string, params ...any) {
-	l.toSlogf(levelError, format, params...)
+	if !l.Enabled(l.unusedCtx, levelError) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelError, fmt.Sprintf(format, params...))
 }
 
 // Criticalf creates a formatted message from the to format specifier along
@@ -98,7 +118,11 @@ func (l *sLogger) Errorf(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Criticalf(format string, params ...any) {
-	l.toSlogf(levelCritical, format, params...)
+	if !l.Enabled(l.unusedCtx, levelCritical) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelCritical, fmt.Sprintf(format, params...))
 }
 
 // Trace formats a message using the default formats for its operands, prepends
@@ -106,7 +130,11 @@ func (l *sLogger) Criticalf(format string, params ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Trace(v ...any) {
-	l.toSlog(levelTrace, v...)
+	if !l.Enabled(l.unusedCtx, levelTrace) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelTrace, fmt.Sprint(v...))
 }
 
 // Debug formats a message using the default formats for its operands, prepends
@@ -114,7 +142,11 @@ func (l *sLogger) Trace(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Debug(v ...any) {
-	l.toSlog(levelDebug, v...)
+	if !l.Enabled(l.unusedCtx, levelDebug) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelDebug, fmt.Sprint(v...))
 }
 
 // Info formats a message using the default formats for its operands, prepends
@@ -122,7 +154,11 @@ func (l *sLogger) Debug(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Info(v ...any) {
-	l.toSlog(levelInfo, v...)
+	if !l.Enabled(l.unusedCtx, levelInfo) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelInfo, fmt.Sprint(v...))
 }
 
 // Warn formats a message using the default formats for its operands, prepends
@@ -130,7 +166,11 @@ func (l *sLogger) Info(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Warn(v ...any) {
-	l.toSlog(levelWarn, v...)
+	if !l.Enabled(l.unusedCtx, levelWarn) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelWarn, fmt.Sprint(v...))
 }
 
 // Error formats a message using the default formats for its operands, prepends
@@ -138,7 +178,11 @@ func (l *sLogger) Warn(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Error(v ...any) {
-	l.toSlog(levelError, v...)
+	if !l.Enabled(l.unusedCtx, levelError) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelError, fmt.Sprint(v...))
 }
 
 // Critical formats a message using the default formats for its operands,
@@ -146,7 +190,11 @@ func (l *sLogger) Error(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) Critical(v ...any) {
-	l.toSlog(levelCritical, v...)
+	if !l.Enabled(l.unusedCtx, levelCritical) {
+		return
+	}
+
+	l.logger.Log(l.unusedCtx, levelCritical, fmt.Sprint(v...))
 }
 
 // TraceS writes a structured log with the given message and key-value pair
@@ -154,7 +202,11 @@ func (l *sLogger) Critical(v ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) TraceS(ctx context.Context, msg string, attrs ...any) {
-	l.toSlogS(ctx, levelTrace, msg, attrs...)
+	if !l.Enabled(ctx, levelTrace) {
+		return
+	}
+
+	l.logger.Log(ctx, levelTrace, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // DebugS writes a structured log with the given message and key-value pair
@@ -162,7 +214,11 @@ func (l *sLogger) TraceS(ctx context.Context, msg string, attrs ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) DebugS(ctx context.Context, msg string, attrs ...any) {
-	l.toSlogS(ctx, levelDebug, msg, attrs...)
+	if !l.Enabled(ctx, levelDebug) {
+		return
+	}
+
+	l.logger.Log(ctx, levelDebug, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // InfoS writes a structured log with the given message and key-value pair
@@ -170,7 +226,11 @@ func (l *sLogger) DebugS(ctx context.Context, msg string, attrs ...any) {
 //
 // This is part of the Logger interface implementation.
 func (l *sLogger) InfoS(ctx context.Context, msg string, attrs ...any) {
-	l.toSlogS(ctx, levelInfo, msg, attrs...)
+	if !l.Enabled(ctx, levelInfo) {
+		return
+	}
+
+	l.logger.Log(ctx, levelInfo, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // WarnS writes a structured log with the given message and key-value pair
@@ -180,11 +240,15 @@ func (l *sLogger) InfoS(ctx context.Context, msg string, attrs ...any) {
 func (l *sLogger) WarnS(ctx context.Context, msg string, err error,
 	attrs ...any) {
 
+	if !l.Enabled(ctx, levelWarn) {
+		return
+	}
+
 	if err != nil {
 		attrs = append([]any{slog.String("err", err.Error())}, attrs...)
 	}
 
-	l.toSlogS(ctx, levelWarn, msg, attrs...)
+	l.logger.Log(ctx, levelWarn, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // ErrorS writes a structured log with the given message and key-value pair
@@ -194,11 +258,15 @@ func (l *sLogger) WarnS(ctx context.Context, msg string, err error,
 func (l *sLogger) ErrorS(ctx context.Context, msg string, err error,
 	attrs ...any) {
 
+	if !l.Enabled(ctx, levelError) {
+		return
+	}
+
 	if err != nil {
 		attrs = append([]any{slog.String("err", err.Error())}, attrs...)
 	}
 
-	l.toSlogS(ctx, levelError, msg, attrs...)
+	l.logger.Log(ctx, levelError, msg, mergeAttrs(ctx, attrs)...)
 }
 
 // CriticalS writes a structured log with the given message and key-value pair
@@ -207,45 +275,16 @@ func (l *sLogger) ErrorS(ctx context.Context, msg string, err error,
 // This is part of the Logger interface implementation.
 func (l *sLogger) CriticalS(ctx context.Context, msg string, err error,
 	attrs ...any) {
+
+	if !l.Enabled(ctx, levelCritical) {
+		return
+	}
+
 	if err != nil {
 		attrs = append([]any{slog.String("err", err.Error())}, attrs...)
 	}
 
-	l.toSlogS(ctx, levelCritical, msg, attrs...)
-}
-
-// toSlogf is a helper method that converts an unstructured log call that
-// contains a format string and parameters for the string into the appropriate
-// form expected by the structured logger.
-func (l *sLogger) toSlogf(level slog.Level, format string, params ...any) {
-	if !l.Enabled(l.unusedCtx, level) {
-		return
-	}
-
-	l.logger.Log(l.unusedCtx, level, fmt.Sprintf(format, params...))
-}
-
-// toSlog is a helper method that converts an unstructured log call that
-// contains a number of parameters into the appropriate form expected by the
-// structured logger.
-func (l *sLogger) toSlog(level slog.Level, v ...any) {
-	if !l.Enabled(l.unusedCtx, level) {
-		return
-	}
-
-	l.logger.Log(l.unusedCtx, level, fmt.Sprint(v...))
-}
-
-// toSlogS is a helper method that can be used by all the structured log calls
-// to access the underlying logger.
-func (l *sLogger) toSlogS(ctx context.Context, level slog.Level, msg string,
-	attrs ...any) {
-
-	if !l.Enabled(ctx, level) {
-		return
-	}
-
-	l.logger.Log(ctx, level, msg, mergeAttrs(ctx, attrs)...)
+	l.logger.Log(ctx, levelCritical, msg, mergeAttrs(ctx, attrs)...)
 }
 
 var _ Logger = (*sLogger)(nil)

--- a/v2/log.go
+++ b/v2/log.go
@@ -27,6 +27,11 @@ type Handler interface {
 
 	// SubSystem returns a copy of the given handler but with the new tag.
 	SubSystem(tag string) Handler
+
+	// WithPrefix returns a copy of the Handler but with the given string
+	// prefixed to each log message. Note that the subsystem of the original
+	// logger is kept but any existing prefix is overridden.
+	WithPrefix(prefix string) Handler
 }
 
 // sLogger is an implementation of Logger backed by a structured sLogger.
@@ -313,6 +318,15 @@ func (l *sLogger) SetLevel(level btclog.Level) {
 // This is part of the Logger interface implementation.
 func (l *sLogger) SubSystem(tag string) Logger {
 	return NewSLogger(l.handler.SubSystem(tag))
+}
+
+// WithPrefix returns a copy of the logger but with the given string prefixed to
+// each log message. Note that the subsystem of the original logger is kept but
+// any existing prefix is overridden.
+//
+// This is part of the Logger interface implementation.
+func (l *sLogger) WithPrefix(prefix string) Logger {
+	return NewSLogger(l.handler.WithPrefix(prefix))
 }
 
 var _ Logger = (*sLogger)(nil)

--- a/v2/log.go
+++ b/v2/log.go
@@ -308,6 +308,13 @@ func (l *sLogger) SetLevel(level btclog.Level) {
 	l.handler.SetLevel(level)
 }
 
+// SubSystem returns a copy of the logger but with the new subsystem tag.
+//
+// This is part of the Logger interface implementation.
+func (l *sLogger) SubSystem(tag string) Logger {
+	return NewSLogger(l.handler.SubSystem(tag))
+}
+
 var _ Logger = (*sLogger)(nil)
 
 func init() {

--- a/v2/log_test.go
+++ b/v2/log_test.go
@@ -1,0 +1,208 @@
+package btclog
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/btcsuite/btclog"
+)
+
+type complexType struct {
+	m map[string]string
+	s []string
+}
+
+var testType = complexType{
+	m: map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	},
+	s: []string{"a", "b", "c"},
+}
+
+// BenchmarkLogger benchmarks the performance of the default v2 logger for each
+// logging level. This helps evaluate the effect of any change to the v2 logger.
+func BenchmarkLogger(b *testing.B) {
+	ctx := context.Background()
+	log := NewSLogger(NewDefaultHandler(io.Discard))
+
+	// Set the level to Info so that Debug logs are skipped.
+	log.SetLevel(LevelInfo)
+
+	tests := []struct {
+		name    string
+		logFunc func()
+	}{
+		{
+			name: "Skipped Simple `f` Log",
+			logFunc: func() {
+				log.Debugf("msg")
+			},
+		},
+		{
+			name: "Skipped Simple `S` Log",
+			logFunc: func() {
+				log.DebugS(ctx, "msg")
+			},
+		},
+		{
+			name: "Simple `f` Log",
+			logFunc: func() {
+				log.Infof("msg")
+			},
+		},
+		{
+			name: "Simple `S` Log",
+			logFunc: func() {
+				log.InfoS(ctx, "msg")
+			},
+		},
+		{
+			name: "Skipped Complex `f` Log",
+			logFunc: func() {
+				log.Debugf("Debugf "+
+					"request_id=%d, "+
+					"complex_type=%v,  "+
+					"type=%T, "+
+					"floating_point=%.12f, "+
+					"hex_value=%x, "+
+					"fmt_string=%s",
+					5, testType, testType,
+					3.141592653589793, []byte{0x01, 0x02},
+					Sprintf("%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			},
+		},
+		{
+			name: "Skipped Complex `S` Log",
+			logFunc: func() {
+				log.DebugS(ctx, "InfoS",
+					"request_id", 5,
+					"complex_type", testType,
+					Fmt("type", "%T", testType),
+					Fmt("floating_point", "%.12f", 3.141592653589793),
+					Hex("hex_value", []byte{0x01, 0x02}),
+					Fmt("fmt_string", "%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			},
+		},
+		{
+			name: "Complex `f` Log",
+			logFunc: func() {
+				log.Infof("Infof "+
+					"request_id=%d, "+
+					"complex_type=%v,  "+
+					"type=%T, "+
+					"floating_point=%.12f, "+
+					"hex_value=%x, "+
+					"fmt_string=%s",
+					5, testType, testType,
+					3.141592653589793, []byte{0x01, 0x02},
+					Sprintf("%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			},
+		},
+		{
+			name: "Complex `S` Log",
+			logFunc: func() {
+				log.InfoS(ctx, "InfoS",
+					"request_id", 5,
+					"complex_type", testType,
+					Fmt("type", "%T", testType),
+					Fmt("floating_point", "%.12f", 3.141592653589793),
+					Hex("hex_value", []byte{0x01, 0x02}),
+					Fmt("fmt_string", "%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				test.logFunc()
+			}
+		})
+	}
+}
+
+// BenchmarkV1vsV2Loggers compares the performance of the btclog V1 logger to
+// the btclog V2 logger in various logs that can be used with both the legacy
+// Logger interface along with the new Logger interface. This, in other words,
+// therefore compares the performance change when the V1 logger is swapped out
+// for the V2 logger.
+func BenchmarkV1vsV2Loggers(b *testing.B) {
+	loggers := []struct {
+		name string
+		btclog.Logger
+	}{
+		{
+			name:   "btclog v1",
+			Logger: btclog.NewBackend(io.Discard).Logger("V1"),
+		},
+		{
+			name:   "btclog v2",
+			Logger: NewSLogger(NewDefaultHandler(io.Discard)),
+		},
+	}
+
+	for _, logger := range loggers {
+		// Test a basic message log with no formatted strings.
+		b.Run(logger.name+" simple", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logger.Infof("Basic")
+			}
+		})
+
+		// Test a basic message log with no formatted strings that gets
+		// skipped due to the current log level.
+		b.Run(logger.name+" skipped simple", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logger.Debugf("Basic")
+			}
+		})
+
+		// Test a log line with a variety of different types and
+		// formats.
+		b.Run(logger.name+" complex", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logger.Infof("Infof "+
+					"request_id=%d, "+
+					"complex_type=%v,  "+
+					"type=%T, "+
+					"floating_point=%.12f, "+
+					"hex_value=%x, "+
+					"fmt_string=%s",
+					5, testType, testType,
+					3.141592653589793, []byte{0x01, 0x02},
+					Sprintf("%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			}
+		})
+
+		// Test a log line with a variety of different types and formats
+		// that then gets skipped due to the current log level.
+		b.Run(logger.name+" skipped complex", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logger.Debugf("Infof "+
+					"request_id=%d, "+
+					"complex_type=%v,  "+
+					"type=%T, "+
+					"floating_point=%.12f, "+
+					"hex_value=%x, "+
+					"fmt_string=%s",
+					5, testType, testType,
+					3.141592653589793, []byte{0x01, 0x02},
+					Sprintf("%s, %v, %T, %.12f",
+						"string", testType, testType,
+						3.141592653589793))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `Enabled` call is also called later on in the slog.Logger's `log` call but by then we have already built the string with fmt.Sprint which can result in quite a big performance hit.

Thanks to @bitromortac for realising this!

EDIT: this has since been updated quite a bit. During review, you can use the new `BenchmarkLogger` and `BenchmarkV1vsV2Loggers` benchmark tests to evaluate each commits impact. 

Note that this has also been expanded to add a `WithPrefix` method on the `Logger` so that we can get rid of the PrefixedLogger in LND