### PR TITLE
btclog: handle nil slices in HexN gracefully

### DIFF
--- a/v2/attrs.go
+++ b/v2/attrs.go
@@ -32,6 +32,11 @@ func Hex2(key string, value []byte) slog.Attr {
 // HexN is a convenience function for hex-encoded log attributes which prints
 // a maximum of n bytes.
 func HexN(key string, value []byte, n uint) slog.Attr {
+	// Handle nil slice gracefully.
+	if value == nil {
+		return slog.String(key, "<nil>")
+	}
+
 	if len(value) <= int(n) {
 		return slog.String(key, hex.EncodeToString(value))
 	}


### PR DESCRIPTION
With this PR `HexN` now checks if the provided byte slice is nil. If
it is, it returns a slog attribute with the string "<nil>". This makes
it easier to search for nil slices in the logs.